### PR TITLE
Upgrade to node:8.1.2, so we can fully use jest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10-alpine
+FROM node:8.1.2-alpine
 RUN apk --no-cache update && \
     apk --no-cache add python py-pip ca-certificates groff less bash make jq curl wget g++ zip git openssh && \
     pip --no-cache-dir install awscli && \


### PR DESCRIPTION
Important structuring features of ES7, such as [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) (which helps to keep code clean and maintainable) depend on a modern Node installation.

[LTS for Node 8.1.2 is only 3 months away.](https://github.com/nodejs/LTS#lts-schedule1) We have an opportunity to be ahead-of-the-curve if we early-adopt ES7. Risk seems minimal, as this is just a build-server, for running live production code. (Our transpiler already uses ES7 transpiled down to ES5.)
