### PR TITLE
Add glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ RUN apk --no-cache update && \
     pip --no-cache-dir install awscli && \
     update-ca-certificates && \
     rm -rf /var/cache/apk/*
+
+# Install glibc
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
+    apk add glibc-2.25-r0.apk
+
 WORKDIR /opt/yarn
 RUN wget https://yarnpkg.com/latest.tar.gz && \
     tar zvxf latest.tar.gz && \


### PR DESCRIPTION
add glibc; dependency for running pact; also generally required by many other kinds of programs [1]

[1] https://gist.github.com/heathd/491870c403accb36105b4113cc329b7e#file-pact-on-alpine-dockerfile-L11,
    https://github.com/pact-foundation/pact-mock-service-npm/issues/18#issuecomment-305076117