### PR TITLE
Add Python 3.6 to image for Python lambdas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM node:6.10-alpine
+FROM node:8.4-alpine
 RUN apk --no-cache update && \
-    apk --no-cache add python py-pip ca-certificates groff less bash make jq curl wget g++ zip git openssh && \
+    apk --no-cache add python python3==3.6.1-r2 python3-dev==3.6.1-r2 py-pip ca-certificates groff less bash make jq curl wget g++ zip git openssh && \
     pip --no-cache-dir install awscli && \
     update-ca-certificates && \
     rm -rf /var/cache/apk/*
 
 # Install glibc
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
+    wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
     apk add glibc-2.25-r0.apk
 
 WORKDIR /opt/yarn
-RUN wget https://yarnpkg.com/latest.tar.gz && \
+RUN wget -q https://yarnpkg.com/latest.tar.gz && \
     tar zvxf latest.tar.gz && \
     rm latest.tar.gz
 ENV PATH "$PATH:/opt/yarn/dist/bin"


### PR DESCRIPTION
The base image needed to be upgraded from Node 6.10 to 8.4 as
node:6.10-alpine uses Alpine 3.4 and only has Python 3.5 packages.
node:8.4-alpine uses Alpine 3.6.

Also fixed 2 wget commands to not spam stdout.