### PR TITLE
Add assume-role functionality to the Makefile

### DIFF
--- a/example/apigw/.env.template
+++ b/example/apigw/.env.template
@@ -6,6 +6,10 @@ GREETING_MESSAGE
 AWS_REGION
 ENV
 
+# If these are set, assume-role before deploying
+AWS_ROLE
+AWS_ACCOUNT_ID
+
 # AWS env vars. If you are using ~/.aws, no need to set values. Values set here will have precedence over ~/.aws when using aws cli
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY

--- a/example/apigw/Makefile
+++ b/example/apigw/Makefile
@@ -9,6 +9,9 @@ endif
 ifdef GO_PIPELINE_NAME
 	ENV_RM_REQUIRED?=rm_env
 endif
+ifdef AWS_ROLE
+	ASSUME_REQUIRED?=assumeRole
+endif
 
 ################
 # Entry Points #
@@ -17,10 +20,10 @@ endif
 build: $(DOTENV_TARGET)
 	docker-compose run --rm serverless make _deps _testUnit _build
 
-deploy: $(ENV_RM_REQUIRED) $(ARTIFACT_PATH) $(DOTENV_TARGET)
+deploy: $(ENV_RM_REQUIRED) $(ARTIFACT_PATH) $(DOTENV_TARGET) $(ASSUME_REQUIRED)
 	docker-compose run --rm serverless make _deploy
 
-remove: $(DOTENV_TARGET)
+remove: $(DOTENV_TARGET) $(ASSUME_REQUIRED)
 	docker-compose run --rm serverless make _remove
 
 shell: $(DOTENV_TARGET)


### PR DESCRIPTION
If AWS_ROLE and AWS_ACCOUNT_ID are set, assume-role before deploying in
order to deploy to other AWS accounts.