### PR TITLE
Zip node_modules after downloading

### DIFF
--- a/example/apigw/.gitignore
+++ b/example/apigw/.gitignore
@@ -1,4 +1,5 @@
 .env
 node_modules
+node_modules.zip
 .serverless
 package/

--- a/example/apigw/Makefile
+++ b/example/apigw/Makefile
@@ -84,4 +84,4 @@ _remove:
 	rm -fr .serverless
 
 _clean:
-	rm -fr node_modules .serverless package
+	rm -fr node_modules node_modules.zip .serverless package

--- a/example/apigw/Makefile
+++ b/example/apigw/Makefile
@@ -50,6 +50,7 @@ _deps:
 	yarn --no-bin-links
 	$(info Install babel-cli globally)
 	yarn global add babel-cli@6.18.0
+	zip -rq node_modules.zip node_modules/
 
 _testUnit:
 	./node_modules/mocha/bin/mocha --compilers js:babel-register test/unit
@@ -73,6 +74,8 @@ _buildLite:
 .PHONY: _buildLite
 
 _deploy:
+	mkdir -p node_modules
+	unzip -qo -d . node_modules.zip
 	rm -fr .serverless
 	sls deploy -v
 


### PR DESCRIPTION
npm/yarn creates a lot of files when downloading dependencies, which can
be slow on filesystems with a lot of IO latency like EFS. This change
zips node_modules after downloading them, which allows you to upload a
single file as an artifact. This also has the benefit of greatly
reducing the artifact size.