### PR TITLE
Automate update process with GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,16 +3,20 @@ on:
   push:
     branches:
       - master
-    paths:
-      - 'Makefile'
-      - 'Dockerfile'
-  # schedule:
-    # - cron: '0 6 1 * *'
+#     paths:
+      # - 'Makefile'
+#       - 'Dockerfile'
+  schedule:
+    # Every Monday at 6 AM
+    - cron: '0 6 * * 1'
 jobs:
   push:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Set IMAGE_NAME
+      if: ${{ secrets.IMAGE_NAME }}
+      run: echo '::set-env name=IMAGE_NAME::${{ secrets.IMAGE_NAME }}'
     - name: Push
       run: make ciPush
       env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,13 +13,8 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
-    env:
-      SECRETS_IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
     steps:
     - uses: actions/checkout@v1
-    - name: Set IMAGE_NAME if defined in secrets
-      if: ${{ env.SECRETS_IMAGE_NAME }}
-      run: echo '::set-env name=IMAGE_NAME::${{ secrets.IMAGE_NAME }}'
     - name: Push
       run: make ciPush
       env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,5 +19,5 @@ jobs:
       run: make ciPush
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'Makefile'
+      - 'Dockerfile'
   # schedule:
     # - cron: '0 6 1 * *'
 jobs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,19 @@
+name: Push
+on:
+  push:
+    branches:
+      - master
+  # schedule:
+    # - cron: '0 6 1 * *'
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Push
+      run: make ciPush
+      env:
+        IMAGE_NAME: flemay/serverless
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,10 +12,12 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME_IN_SECRETS: ${{ secrets.IMAGE_NAME}}
     steps:
     - uses: actions/checkout@v1
-    - name: Set IMAGE_NAME if set in secrets
-      if: ${{ env.IMAGE_NAME }}
+    - name: Set IMAGE_NAME if defined in secrets
+      if: ${{ env.IMAGE_NAME_IN_SECRETS }}
       run: echo '::set-env name=IMAGE_NAME::${{ secrets.IMAGE_NAME }}'
     - name: Push
       run: make ciPush

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,12 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set IMAGE_NAME
-      if: ${{ secrets.IMAGE_NAME }}
+      if: ${{ secrets.IMAGE_NAME != null }}
       run: echo '::set-env name=IMAGE_NAME::${{ secrets.IMAGE_NAME }}'
     - name: Push
       run: make ciPush
       env:
-        IMAGE_NAME: flemay/serverless
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set IMAGE_NAME
+    - name: Set IMAGE_NAME if set in secrets
       if: ${{ env.IMAGE_NAME }}
       run: echo '::set-env name=IMAGE_NAME::${{ secrets.IMAGE_NAME }}'
     - name: Push

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ on:
       - 'Dockerfile'
       - '.github/workflows/push.yml'
   schedule:
-    # Every Monday at 6 AM
+    # Every Monday at 6 AM (EDT)
     - cron: '0 6 * * 1'
 jobs:
   push:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set IMAGE_NAME
-      if: ${{ secrets.IMAGE_NAME != null }}
+      if: ${{ env.IMAGE_NAME }}
       run: echo '::set-env name=IMAGE_NAME::${{ secrets.IMAGE_NAME }}'
     - name: Push
       run: make ciPush

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,9 +3,10 @@ on:
   push:
     branches:
       - master
-#     paths:
-      # - 'Makefile'
-#       - 'Dockerfile'
+    paths:
+      - 'Makefile'
+      - 'Dockerfile'
+      - '.github/workflows/push.yml'
   schedule:
     # Every Monday at 6 AM
     - cron: '0 6 * * 1'
@@ -13,11 +14,11 @@ jobs:
   push:
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME_IN_SECRETS: ${{ secrets.IMAGE_NAME}}
+      SECRETS_IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
     steps:
     - uses: actions/checkout@v1
     - name: Set IMAGE_NAME if defined in secrets
-      if: ${{ env.IMAGE_NAME_IN_SECRETS }}
+      if: ${{ env.SECRETS_IMAGE_NAME }}
       run: echo '::set-env name=IMAGE_NAME::${{ secrets.IMAGE_NAME }}'
     - name: Push
       run: make ciPush

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,5 +7,4 @@ jobs:
     - uses: actions/checkout@v1
     - name: Test
       run: make ciTest
-      env:
-        IMAGE_NAME: flemay/serverless
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: Test
+on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Test
+      run: make ciTest
+      env:
+        IMAGE_NAME: flemay/serverless

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ clean:
 	docker rmi -f $(IMAGE)
 
 env-%:
-	$(info check if $* is not empty)
+	$(info Check if $* is not empty)
 	@docker run --rm -e ENV_VAR=$($*) node:alpine sh -c '[ -z "$$ENV_VAR" ] && echo "$* is empty" && exit 1 || exit 0'
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SERVERLESS_VERSION ?= $(shell docker run --rm node:alpine npm show serverless version)
-IMAGE_NAME ?= amaysim/serverless
+IMAGE_NAME ?= flemay/serverless
 IMAGE = $(IMAGE_NAME):$(SERVERLESS_VERSION)
 ROOT_DIR = $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SERVERLESS_VERSION ?= $(shell docker run --rm node:alpine npm show serverless version)
-IMAGE_NAME ?= flemay/serverless
+IMAGE_NAME ?= amaysim/serverless
 IMAGE = $(IMAGE_NAME):$(SERVERLESS_VERSION)
 ROOT_DIR = $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: env-SERVERLESS_VERSION
 
 push: env-DOCKER_USERNAME env-DOCKER_PASSWORD
 	@echo "$(DOCKER_PASSWORD)" | docker login --username "$(DOCKER_USERNAME)" --password-stdin docker.io
-	docker push
+	docker push $(IMAGE)
 	docker logout
 
 pull:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ SERVERLESS_VERSION ?= $(shell docker run --rm node:alpine npm show serverless ve
 IMAGE_NAME ?= amaysim/serverless
 IMAGE = $(IMAGE_NAME):$(SERVERLESS_VERSION)
 
+ciTest: build clean
+
 build: env-SERVERLESS_VERSION
 	docker build --build-arg SERVERLESS_VERSION=$(SERVERLESS_VERSION) -t $(IMAGE) .
 	docker run --rm $(IMAGE) bash -c 'serverless --version | grep $(SERVERLESS_VERSION)'
@@ -16,6 +18,9 @@ pull:
 
 shell:
 	docker run --rm -it -v $(PWD):/opt/app $(IMAGE) bash
+
+clean:
+	docker rmi -f $(IMAGE)
 
 env-%:
 	$(info check if $* is not empty)

--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,5 @@ clean:
 
 env-%:
 	$(info Check if $* is not empty)
-	@docker run --rm -e ENV_VAR=$($*) node:alpine sh -c '[ -z "$$ENV_VAR" ] && echo "$* is empty" && exit 1 || exit 0'
+	@docker run --rm -e ENV_VAR=$($*) node:alpine sh -c '[ -z "$$ENV_VAR" ] && echo "Error: $* is empty" && exit 1 || exit 0'
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ IMAGE = $(IMAGE_NAME):$(SERVERLESS_VERSION)
 
 ciTest: build clean
 
+ciPush: build push clean
+
 build: env-SERVERLESS_VERSION
 	docker build --build-arg SERVERLESS_VERSION=$(SERVERLESS_VERSION) -t $(IMAGE) .
 	docker run --rm $(IMAGE) bash -c 'serverless --version | grep $(SERVERLESS_VERSION)'
@@ -24,5 +26,5 @@ clean:
 
 env-%:
 	$(info check if $* is not empty)
-	@docker run --rm -e ENV_VAR=$($*) node:alpine sh -c '[ -z "$$ENV_VAR" ] && echo $* is empty && exit 1 || exit 0'
+	@docker run --rm -e ENV_VAR=$($*) node:alpine sh -c '[ -z "$$ENV_VAR" ] && echo "$* is empty" && exit 1 || exit 0'
 

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,5 @@ env-%:
 	$(info Check if $* is not empty)
 	@docker run --rm -e ENV_VAR=$($*) node:alpine sh -c '[ -z "$$ENV_VAR" ] && echo "$* is empty" && exit 1 || exit 0'
 
+test:
+	echo test

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,3 @@ env-%:
 	$(info Check if $* is not empty)
 	@docker run --rm -e ENV_VAR=$($*) node:alpine sh -c '[ -z "$$ENV_VAR" ] && echo "$* is empty" && exit 1 || exit 0'
 
-test:
-	echo test

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,23 @@
-SERVERLESS_VERSION = 1.71.1
-IMAGE_NAME ?= amaysim/serverless:$(SERVERLESS_VERSION)
-TAG = $(SERVERLESS_VERSION)
+SERVERLESS_VERSION ?= $(shell docker run --rm node:alpine npm show serverless version)
+IMAGE_NAME ?= amaysim/serverless
+IMAGE = $(IMAGE_NAME):$(SERVERLESS_VERSION)
 
-build:
-	docker build --build-arg SERVERLESS_VERSION=$(SERVERLESS_VERSION) -t $(IMAGE_NAME) .
+build: env-SERVERLESS_VERSION
+	docker build --build-arg SERVERLESS_VERSION=$(SERVERLESS_VERSION) -t $(IMAGE) .
+	docker run --rm $(IMAGE) bash -c 'serverless --version | grep $(SERVERLESS_VERSION)'
+
+push: env-DOCKER_USERNAME env-DOCKER_PASSWORD
+	@echo "$(DOCKER_PASSWORD)" | docker login --username "$(DOCKER_USERNAME)" --password-stdin docker.io
+	docker push
+	docker logout
 
 pull:
-	docker pull $(IMAGE_NAME)
+	docker pull $(IMAGE)
 
 shell:
-	docker run --rm -it -v $(PWD):/opt/app $(IMAGE_NAME) bash
+	docker run --rm -it -v $(PWD):/opt/app $(IMAGE) bash
 
-tag:
-	-git tag -d $(TAG)
-	-git push origin :refs/tags/$(TAG)
-	git tag $(TAG)
-	git push origin $(TAG)
+env-%:
+	$(info check if $* is not empty)
+	@docker run --rm -e ENV_VAR=$($*) node:alpine sh -c '[ -z "$$ENV_VAR" ] && echo $* is empty && exit 1 || exit 0'
+

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ build: env-SERVERLESS_VERSION
 	docker build --build-arg SERVERLESS_VERSION=$(SERVERLESS_VERSION) -t $(IMAGE) .
 	docker run --rm $(IMAGE) bash -c 'serverless --version | grep $(SERVERLESS_VERSION)'
 
-push: env-DOCKER_USERNAME env-DOCKER_PASSWORD
-	@echo "$(DOCKER_PASSWORD)" | docker login --username "$(DOCKER_USERNAME)" --password-stdin docker.io
+push: env-DOCKER_USERNAME env-DOCKER_ACCESS_TOKEN
+	@echo "$(DOCKER_ACCESS_TOKEN)" | docker login --username "$(DOCKER_USERNAME)" --password-stdin docker.io
 	docker push $(IMAGE)
 	docker logout
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SERVERLESS_VERSION ?= $(shell docker run --rm node:alpine npm show serverless version)
 IMAGE_NAME ?= amaysim/serverless
 IMAGE = $(IMAGE_NAME):$(SERVERLESS_VERSION)
+ROOT_DIR = $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 ciTest: build clean
 
@@ -19,7 +20,7 @@ pull:
 	docker pull $(IMAGE)
 
 shell:
-	docker run --rm -it -v $(PWD):/opt/app $(IMAGE) bash
+	docker run --rm -it -v $(ROOT_DIR):/opt/app $(IMAGE) bash
 
 clean:
 	docker rmi -f $(IMAGE)


### PR DESCRIPTION
Who does really like to manually update a Docker image based on a release of a component? What if the image gets automatically versioned... FOREVER?

This is the simplest (I think) way to automate `amaysim/serverless` updates. Every week, a GitHub Action runs `make ciPush` which gets the latest Serverless version from NPM, builds a new Docker image version, and pushes it to Docker Hub.

## Pros

- No need to manually update the Docker image, EVER!
- Periodically updates the image and all its dependencies
- GitHub Action to build/test upon a PR event is included
- GitHub Action to build/test and push upon a push to `master`
- Only build when there is a change to `Makefile`, `Dockerfile`, and GitHub Action `push.yml`

## Cons

Since this version is meant to be minimal, and probably incremental, there are few cons:

- The repository itself won't have git tags anymore. Do we need them?
- To know what is the latest Docker image version, one needs to check Docker Hub or GitHub Actions
- The immutability of a given image version won't be guaranteed, only the version of Serverless, because the same version can be built/pushed more than once.
    - A check could eventually be added
- Not tested on Windows

## Other questions

- Do we really need the example? We could potentially have "how to use the image" in the README.
- Would we need Docker image `latest` tag?

## Todo before merging

- Delete automatic Docker Hub build because we would rely on GitHub to build the image
- Set `DOCKER_USERNAME` and `DOCKER_PASSWORD` as GitHub secrets
    - Make sure the `DOCKER_PASSWORD` is a Docker Access Token, not the user's password 
- Protect `master` branch on GitHub to execute the github action before merging

As I said, this is meant to be incremental. What are your thoughts?