### PR TITLE
update node.js runtime version to latest supported version

### DIFF
--- a/example/apigw/serverless.yml
+++ b/example/apigw/serverless.yml
@@ -3,7 +3,7 @@ package:
   artifact: package/package.zip
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs12.x
   region: ${env:AWS_REGION}
   stage: ${env:ENV}
 


### PR DESCRIPTION
Updated the `serverless.yml` file to bump the Node.js version to the latest supported AWS Lambda runtime version: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

Links to open issue: https://github.com/amaysim-au/docker-serverless/pull/37#issue-435803845