### PR TITLE
use alpine 3.15 which has python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG NODE_ALPINE_IMAGE=node:lts-alpine
-
+ARG NODE_ALPINE_IMAGE
 FROM $NODE_ALPINE_IMAGE
 
 # SERVERLESS_VERSION is set explicitly in the Makefile used to build, otherwise

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NODE_ALPINE_IMAGE ?= node:lts-alpine
+NODE_ALPINE_IMAGE ?= node:lts-alpine3.15
 SERVERLESS_VERSION ?= $(shell docker run --rm $(NODE_ALPINE_IMAGE) npm show serverless version)
 IMAGE_NAME ?= amaysim/serverless
 IMAGE = $(IMAGE_NAME):$(SERVERLESS_VERSION)


### PR DESCRIPTION
NodeJS team recently changed `node:lts-alpine` to use Alpine 3.16 which [removed python 2](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#Python_2_has_been_removed).