### PR TITLE
Fix support for VSCode dev-containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN apk --no-cache add python3 python3-dev py-pip ca-certificates groff less bas
     update-ca-certificates
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
-    apk add glibc-2.25-r0.apk && \
-    rm -f glibc-2.25-r0.apk
+    wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk && \
+    apk add --force-overwrite glibc-2.34-r0.apk && \
+    rm -f glibc-2.34-r0.apk
 
 RUN mkdir -p /tmp/yarn && \
     mkdir -p /opt/yarn/dist && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM $NODE_ALPINE_IMAGE
 ARG SERVERLESS_VERSION=latest
 ENV SERVERLESS_VERSION $SERVERLESS_VERSION
 
-RUN apk --no-cache add python2 python3 python3-dev py-pip ca-certificates groff less bash make jq curl wget g++ zip git openssh && \
+RUN apk --no-cache add python3 python3-dev py-pip ca-certificates groff less bash make jq curl wget g++ zip git openssh && \
     pip --no-cache-dir install awscli && \
     update-ca-certificates
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NODE_ALPINE_IMAGE ?= node:lts-alpine3.15
+NODE_ALPINE_IMAGE ?= node:lts-alpine3.17
 SERVERLESS_VERSION ?= $(shell docker run --rm $(NODE_ALPINE_IMAGE) npm show serverless version)
 IMAGE_NAME ?= amaysim/serverless
 IMAGE = $(IMAGE_NAME):$(SERVERLESS_VERSION)


### PR DESCRIPTION
This PR;
* Removes python2 (python3 is still present)
* Updates glibc from 2.25 to 2.34 (this is the latest version that supports pact)
* Updates Alpine from 3.15 to 3.17 (this fixes the dev-container issue)

This is all to allow dev-containers in the latest release of VSCode to work with the amaysim/serverless image. There is an issue with either the latest version of VSCode (1.78.2) or in Alpine 3.15. Updating to Alpine 3.17 allows everything to work, and doesn't require new developers to pin VSCode to an older release.

✅ Threads discussing if python2 can be removed and how to determine the impact to Pact.
1. https://amaysim.slack.com/archives/G4VJU8CF6/p1685396761888339
2. https://amaysim.slack.com/archives/CSR386X3Q/p1685333173588729
* Python 2 can be removed as it's been sunsetted and deprecated by AWS.
* I've found the most recent version of glibc that works with pact (not the most recent version of glibc), so pact can be used, although I'd recommend using the [dedicated containers](https://docs.pact.io/docker) for that.