### PR TITLE
switch to apk version of aws cli, add poetry, bump to alpine 3.19 to get python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ FROM $NODE_ALPINE_IMAGE
 ARG SERVERLESS_VERSION=latest
 ENV SERVERLESS_VERSION $SERVERLESS_VERSION
 
-RUN apk --no-cache add python3 python3-dev py-pip ca-certificates groff less bash make cmake jq curl wget g++ zip git openssh && \
-    pip --no-cache-dir install awscli && \
+RUN apk --no-cache add python3 python3-dev py-pip poetry aws-cli ca-certificates groff less bash make cmake jq curl wget g++ zip git openssh && \
     update-ca-certificates
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NODE_ALPINE_IMAGE ?= node:lts-alpine3.17
+NODE_ALPINE_IMAGE ?= node:lts-alpine3.19
 SERVERLESS_VERSION ?= $(shell docker run --rm $(NODE_ALPINE_IMAGE) npm show serverless version)
 IMAGE_NAME ?= amaysim/serverless
 IMAGE = $(IMAGE_NAME):$(SERVERLESS_VERSION)


### PR DESCRIPTION
* Switch to use the Alpine package of the AWS CLI
* Add `poetry` package, needed by some python deployments
* Bump to Alpine 3.19, to get python 3.11